### PR TITLE
set UTF-8 encoding in compiler plugin

### DIFF
--- a/analyzer-core/pom.xml
+++ b/analyzer-core/pom.xml
@@ -20,6 +20,7 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Necessary so that compilation works fine on windows OS.